### PR TITLE
Refactor: 게시글 유사도 데이터 모델을 `posts` 컬렉션에 추가 및 텔레그램 채널 연결 과정에서의 오류 수정

### DIFF
--- a/core/mongo/post.py
+++ b/core/mongo/post.py
@@ -50,6 +50,16 @@ class TelegramPromotion(BaseModel):
         description="List of Telegram channel identifiers associated with the promotion content."
     )
 
+class PostSimilarity(BaseModel):
+    post_id: str = Field(
+        title="Post ID (ObjectID)",
+        description="ID of the post to compare with",
+    )
+    similarity: float = Field(
+        title="Similarity",
+        description="Similarity score between the post and the comparison post",
+    )
+
 class PostAnalysisResult(BaseModel):
     drugs_related: bool = Field(
         default=False,
@@ -118,6 +128,7 @@ class PostFields(StrEnum):
     published_at = "published_at"
     discovered_at = "discovered_at"
     updated_at = "updated_at"
+    similarities = "similarities"
 
 class Post(BaseMongoObject):
     title: str = Field(
@@ -174,6 +185,12 @@ class Post(BaseMongoObject):
         default_factory=datetime.now,
         title="Updated Date",
         description="Date when the content was last updated",
+    )
+
+    similarities: list[PostSimilarity] = Field(
+        default_factory=list,
+        title="Similar Posts with Similarity Score",
+        description="List of posts and its similarity scores similar to the current post"
     )
 
     def __eq__(self, other):

--- a/routes/responses.py
+++ b/routes/responses.py
@@ -145,6 +145,7 @@ class TeleprobeHTTPException:
         ChannelNotWatchedError: HTTP_404_NOT_FOUND,
         UsernameNotFoundError: HTTP_404_NOT_FOUND,
         ConnectionError: HTTP_503_SERVICE_UNAVAILABLE,
+        ChannelNotJoinedError: HTTP_403_FORBIDDEN,
     }
     _exception_detail_map: Dict[type[Exception], str]= {
         ConnectionError: "텔레그램 서비스에 연결할 수 없는 상태입니다."

--- a/routes/teleprobe/register.py
+++ b/routes/teleprobe/register.py
@@ -196,14 +196,13 @@ async def register(
     """
     with get_db() as db:
         # TeleprobeClient 생성 (자동으로 연결 테스트)
-        logger.info(f"TeleprobeClient 등록 시작: api_id={client.api_id}")
         with TeleprobeClient(
             api_id=credentials.api_id,
             api_hash=credentials.api_hash,
             session_string=credentials.session_string,
             phone=credentials.phone
         ) as client:
-
+            logger.info(f"TeleprobeClient 등록 시작: api_id={client.api_id}")
             # 기존 토큰 확인 (같은 api_id로 이미 등록된 경우)
             existing_token: Optional[TelegramToken] = db.query(TelegramToken).filter(
                 TelegramToken.api_id == client.api_id,

--- a/teleprobe/errors.py
+++ b/teleprobe/errors.py
@@ -36,6 +36,7 @@ __all__ = [
     'UnknownInvitationTypeError',
     'SessionStringInvalidError',
     'ChannelNotFoundError',
+    'ChannelNotJoinedError',
     'EntityNotFoundError',
     'UsernameNotFoundError',
     'ChannelKeyInvalidError',
@@ -130,6 +131,11 @@ class ChannelNotFoundError(Exception):
     """
     def __init__(self, msg: Optional[str] = None):
         super().__init__(msg or "Channel not found.")
+
+class ChannelNotJoinedError(Exception):
+    """채널 식별자가 정수 형태이지만 아직 참가하지 않아 캐시에 없는 경우에 대한 예외 클래스"""
+    def __init__(self, msg: Optional[str] = None):
+        super().__init__(msg or "Channel not joined yet.")
 
 class UsernameNotFoundError(Exception):
     """사용자명을 찾을 수 없는 경우에 대한 예외 클래스
@@ -241,6 +247,7 @@ ACCEPTABLE_EXCEPTIONS = (
     UnknownInvitationTypeError,
     SessionStringInvalidError,
     ChannelNotFoundError,
+    ChannelNotJoinedError,
     EntityNotFoundError,
     UsernameNotFoundError,
     ChannelKeyInvalidError,


### PR DESCRIPTION
### 📚 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #22 

### ✔️ 작업 내용

- 채널 ID를 통한 접근 시 기존 참여 여부를 확인하는 로직 추가.
- 게시글 유사도 데이터 모델(`PostSimilarity`) 추가.
- MongoDB 컬렉션의 새 필드 `similarities` 추가 정의.

### 📝 리뷰 요청사항

- 

### 💻 테스트 결과

- 