### PR TITLE
Bug: Channel 노드의 `channel_id`를 정수형으로 저장하도록 수정

### DIFF
--- a/core/neo4j/ogm.py
+++ b/core/neo4j/ogm.py
@@ -200,7 +200,7 @@ class ChannelNode(StructuredNode):
     MongoDB의 channels 문서를 그래프 노드로 투영합니다.
     """
     __label__ = "Channel"
-    channel_id = StringProperty(unique_index=True, required=True)
+    channel_id = IntegerProperty(unique_index=True, required=True)
     status = StringProperty()
     title = StringProperty()
     username = StringProperty()


### PR DESCRIPTION
### 📚 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #38 

### ✔️ 작업 내용

- Channel 노드의 `channel_id`를 정수형으로 저장하도록 수정

### 📝 리뷰 요청사항

- 

### 💻 테스트 결과

- sync API 실행 시 정수형으로 저장됨을 확인